### PR TITLE
Update requirements.txt to also install fairseq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ transformers>=4.0.0
 tqdm
 dill
 unidecode
+fairseq


### PR DESCRIPTION
Fairseq is required for running diagNNose, so I have added it to the `requirements.txt`.